### PR TITLE
Fix section 1.1.5

### DIFF
--- a/tasks/section_01_level1.yml
+++ b/tasks/section_01_level1.yml
@@ -221,36 +221,6 @@
       - section1.1
       - section1.1.5
 
-  - mountopts:
-      name: /var
-      option: nosuid
-      state: present
-    when: var_partition.rc == 0
-    tags:
-      - section1
-      - section1.1
-      - section1.1.5
-
-  - mountopts:
-      name: /var
-      option: noexec
-      state: present
-    when: var_partition.rc == 0
-    tags:
-      - section1
-      - section1.1
-      - section1.1.5
-
-  - mountopts:
-      name: /var
-      option: nodev
-      state: present
-    when: var_partition.rc == 0
-    tags:
-      - section1
-      - section1.1
-      - section1.1.5
-
   - name: 1.1.6 Ensure separate partition exists for /var/tmp (Scored)
     command: grep '\s/var/tmp\s' /etc/fstab
     register: var_tmp_partition


### PR DESCRIPTION
Those options nosuid noexec, nodev are not required for /tmp.
CIS Ubuntu Linux 16.04 LTS Benchmark v1.0.0 - 10-04-2016