### PR TITLE
Adding purge statement to the telnet removal

### DIFF
--- a/tasks/section_02_level3.yml
+++ b/tasks/section_02_level3.yml
@@ -34,6 +34,7 @@
     apt:
       name: telnet
       state: absent
+      purge: yes
     tags:
       - section2
       - section2.3


### PR DESCRIPTION
telnet client is installed by default in ubuntu 16 install.  Removing it still causes false positives with some audit scanners like tenable if you don't also purge the config files.