### PR TITLE
hashing algorithm overwrites reuse fix

### DIFF
--- a/tasks/section_05_level3.yml
+++ b/tasks/section_05_level3.yml
@@ -45,23 +45,14 @@
       - section5.3
       - section5.3.2
 
-  - name: 5.3.3 Ensure password reuse is limited (Scored)
+  - name: "5.3.3 Ensure password reuse is limited (Scored)\n
+           5.3.4 Ensure password hashing algorithm is SHA-512 (Scored)"
     lineinfile:
       name: /etc/pam.d/common-password
       regexp: '^password\s+sufficient\s+pam_unix.so'
-      line: 'password sufficient pam_unix.so remember=5'
+      line: 'password sufficient pam_unix.so sha512 remember=5'
     tags:
       - section5
       - section5.3
       - section5.3.3
-
-  - name: 5.3.4 Ensure password hashing algorithm is SHA-512 (Scored)
-    lineinfile:
-      name: /etc/pam.d/common-password
-      regexp: '^password\s+\S+\s+pam_unix.so'
-      line: 'password sufficient pam_unix.so sha512'
-    tags:
-      - section5
-      - section5.3
       - section5.3.4
-


### PR DESCRIPTION
This combines 5.3.3 and 5.3.4.  5.3.4 should not be too controversial compared to 5.3.3 for user impact, so it seems fine to combine the two into one so that both options can easily be set without complicated regexp trying to keep other set options.