### PR TITLE
max_log_file was giving multiple lines

### DIFF
--- a/tasks/section_04_level1.yml
+++ b/tasks/section_04_level1.yml
@@ -12,6 +12,7 @@
   - name: 4.1.1.1 Ensure audit log storage size is configured (Not Scored)
     lineinfile: 
         dest: /etc/audit/auditd.conf
+        regexp: '^[\s]*max_log_file[\s]*='
         line: 'max_log_file = {{max_log_file_auditd}}'
         state: present
         create: yes


### PR DESCRIPTION
At least in my auditd.conf file I was getting multiple lines for max_log_file.  This should match the previous line in the file better and is the same regexp that the CIS audit checks.