### PR TITLE
Disable 4.1.3 when the rest of 4.1 is disabled

### DIFF
--- a/tasks/section_04_level1.yml
+++ b/tasks/section_04_level1.yml
@@ -63,6 +63,7 @@
     lineinfile:
         dest: /etc/default/grub
         line: 'GRUB_CMDLINE_LINUX="audit=1"'
+    when: enable_auditd == True
     tags:
       - section4
       - section4.1


### PR DESCRIPTION
There was no flag check to make sure this isn't ran when 4.1 is disabled.

Current setup results in grub running as if SELinux has been installed and setup when it might not exist on the system.
New setup prevents altering the grub setup.